### PR TITLE
fix: upgrade pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add build-base
 RUN mkdir /install
 WORKDIR /install
 COPY requirement.txt /requirement.txt
+RUN pip install --upgrade pip
 RUN pip install --prefix=/install -r /requirement.txt
 FROM base
 COPY --from=builder /install /usr/local


### PR DESCRIPTION
Last release for agent Nebula failed due to pip infinite search. This PR upgrades pip in the Dockerfile before installing reqs.