### PR TITLE
feature: add support for ubjson

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -21,3 +21,6 @@ disallow_any_unimported = True
 warn_return_any = True
 exclude = .*_pb2.py
 
+[mypy-ubjson]
+ignore_missing_imports = True
+

--- a/agent/nebula_agent.py
+++ b/agent/nebula_agent.py
@@ -5,8 +5,9 @@ import json
 import logging
 import os
 import pathlib
-from typing import Any
+from typing import Any, Callable
 
+import ubjson
 from ostorlab.agent import agent, definitions as agent_definitions
 from ostorlab.agent.message import message as m
 from ostorlab.runtimes import definitions as runtime_definitions
@@ -21,14 +22,30 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-SUPPORTED_FILE_TYPES = ["json"]
-
 
 class CustomEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> Any:
         if isinstance(obj, bytes) is True:
             return base64.b64encode(obj).decode("utf-8")
         return json.JSONEncoder.default(self, obj)
+
+
+def _write_json(data: Any, path: pathlib.Path) -> None:
+    """Write data to a JSON file."""
+    with open(path, "w") as f:
+        f.write(json.dumps(data, cls=CustomEncoder))
+
+
+def _write_ubjson(data: Any, path: pathlib.Path) -> None:
+    """Write data to a UBJSON file."""
+    with open(path, "wb") as f:
+        ubjson.dump(data, f)
+
+
+SUPPORTED_FILE_TYPES = {
+    "json": _write_json,
+    "ubjson": _write_ubjson,
+}
 
 
 class NebulaAgent(agent.Agent):
@@ -43,8 +60,13 @@ class NebulaAgent(agent.Agent):
         self._file_type = self.args.get("file_type", "json")
         if self._file_type.lower() not in SUPPORTED_FILE_TYPES:
             raise ValueError(
-                f"File type {self._file_type} is not supported. Supported file types are {SUPPORTED_FILE_TYPES}"
+                f"File type {self._file_type} is not supported. Supported file types are {list(SUPPORTED_FILE_TYPES.keys())}"
             )
+
+        self._writer: Callable[[Any, pathlib.Path], None] = SUPPORTED_FILE_TYPES[
+            self._file_type
+        ]
+
         self._output_directory: pathlib.Path
         output_directory: str | None = self.args.get("output_directory")
         if output_directory is not None:
@@ -56,6 +78,7 @@ class NebulaAgent(agent.Agent):
                 pathlib.Path("/output") / f"scan_{self.universe}_messages"
             )
         self._output_directory.mkdir(parents=True, exist_ok=True)
+        self._message_order: dict[str, int] = {}
 
     def process(self, message: m.Message) -> None:
         """Process the message and persist it to the file type and location specified in the agent definition.
@@ -64,22 +87,26 @@ class NebulaAgent(agent.Agent):
             message: The message to process.
         """
         logger.info("Processing message of selector : %s", message.selector)
+        self._persist_message(message)
 
-        if self._file_type == "json":
-            self._persist_to_json(message)
-
-    def _persist_to_json(self, message_to_persist: m.Message) -> None:
-        """Persist message to JSON file.
+    def _persist_message(self, message_to_persist: m.Message) -> None:
+        """Persist message to a file.
 
         Args:
             message_to_persist: The message to persist.
         """
         data = message_to_persist.data
         selector = message_to_persist.selector
-        file_path = self._output_directory / f"{selector}_messages.json"
 
-        with open(file_path, "a") as file:
-            file.write(json.dumps(data, cls=CustomEncoder) + "\n")
+        selector_dir = self._output_directory / f"{selector}_messages"
+        selector_dir.mkdir(parents=True, exist_ok=True)
+
+        order = self._message_order.get(selector, 0)
+        file_path = selector_dir / f"{order}.{self._file_type}"
+
+        self._writer(data, file_path)
+
+        self._message_order[selector] = order + 1
 
 
 if __name__ == "__main__":

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -77,7 +77,7 @@ mounts:
 args:
   - name: "file_type"
     type: "string"
-    description: "The type of the file where the message will be persisted."
+    description: "The type of the file where the message will be persisted. The supported types are: json, ubjson."
     value: "json"
   - name: "output_directory"
     type: "string"

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,2 +1,3 @@
 ostorlab[agent]
 rich
+py-ubjson

--- a/tests/nebula_agent_test.py
+++ b/tests/nebula_agent_test.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 
 import pytest
+import ubjson
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.agent.message import message as msg
 from ostorlab.runtimes import definitions as runtime_definitions
@@ -52,9 +53,13 @@ def testAgentNebula_whenFileTypeIsJson_persistMessage(
 
         nebula_test_agent.process(link_message)
 
-        assert os.path.exists("/output/scan_43_messages")
-        assert len(os.listdir("/output/scan_43_messages")) == 1
-        with open("/output/scan_43_messages/v3.asset.link_messages.json") as file:
+        scan_dir = "/output/scan_43_messages"
+        assert os.path.exists(scan_dir)
+        assert len(os.listdir(scan_dir)) == 1
+        message_dir = f"{scan_dir}/v3.asset.link_messages"
+        assert os.path.exists(message_dir)
+        assert len(os.listdir(message_dir)) == 1
+        with open(f"{message_dir}/0.json") as file:
             assert sorted(json.load(file).items()) == sorted(
                 json.loads(expected_output).items()
             )
@@ -80,14 +85,53 @@ def testAgentNebula_whenFileTypeIsJson_persistMultipleLinkMessages(
         for message in multiple_link_messages:
             nebula_test_agent.process(message)
 
-        file_path = "/output/scan_43_messages"
-        assert os.path.exists(file_path)
-        assert len(os.listdir(file_path)) == 1
-        with open(f"{file_path}/v3.asset.link_messages.json", "r") as file:
-            lines = file.readlines()
-        assert len(lines) == len(expected_output)
-        for line, expected_line in zip(lines, expected_output):
-            assert line.strip() == expected_line.strip()
+        scan_dir = "/output/scan_43_messages"
+        assert os.path.exists(scan_dir)
+        assert len(os.listdir(scan_dir)) == 1
+        message_dir = f"{scan_dir}/v3.asset.link_messages"
+        assert os.path.exists(message_dir)
+        files = sorted(os.listdir(message_dir))
+        assert len(files) == len(expected_output)
+        for i, expected in enumerate(expected_output):
+            with open(f"{message_dir}/{i}.json", "r") as f:
+                content = f.read()
+                assert content.strip() == expected.strip()
+
+
+def testAgentNebula_whenFileTypeIsUbjson_persistMessage(
+    agent_definition: agent_definitions.AgentDefinition,
+    link_message: msg.Message,
+) -> None:
+    """Test that NebulaAgent persists message to ubjson file."""
+    os.environ["UNIVERSE"] = "43"
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/nebula",
+        bus_url="NA",
+        bus_exchange_topic="NA",
+        args=[
+            utils_definitions.Arg(
+                name="file_type",
+                type="string",
+                value=json.dumps("ubjson").encode(),
+            ),
+        ],
+        healthcheck_port=5301,
+        redis_url="redis://guest:guest@localhost:6379",
+    )
+    with fake_filesystem_unittest.Patcher():
+        expected_output = {"url": "https://ostorlab.co", "method": b"GET"}
+        nebula_test_agent = nebula_agent.NebulaAgent(agent_definition, settings)
+
+        nebula_test_agent.process(link_message)
+
+        scan_dir = "/output/scan_43_messages"
+        assert os.path.exists(scan_dir)
+        assert len(os.listdir(scan_dir)) == 1
+        message_dir = f"{scan_dir}/v3.asset.link_messages"
+        assert os.path.exists(message_dir)
+        assert len(os.listdir(message_dir)) == 1
+        with open(f"{message_dir}/0.ubjson", "rb") as file:
+            assert ubjson.load(file) == expected_output
 
 
 def testAgentNebula_whenFileTypeIsJson_persistMultipleMessages(
@@ -114,24 +158,27 @@ def testAgentNebula_whenFileTypeIsJson_persistMultipleMessages(
         for message in multiple_messages:
             nebula_test_agent.process(message)
 
-        file_path = "/output/scan_43_messages"
-        assert os.path.exists(file_path)
-        assert len(os.listdir(file_path)) == 3
-        assert os.path.exists(f"{file_path}/v3.asset.link_messages.json") is True
-        with open(f"{file_path}/v3.asset.link_messages.json", "r") as file:
-            lines = file.readlines()
-        assert len(lines) == 1
-        assert lines[0].strip() == expected_output[0].strip()
-        assert os.path.exists(f"{file_path}/v3.asset.domain_name_messages.json") is True
-        with open(f"{file_path}/v3.asset.domain_name_messages.json", "r") as file:
-            lines = file.readlines()
-        assert len(lines) == 1
-        assert lines[0].strip() == expected_output[1].strip()
-        assert os.path.exists(f"{file_path}/v3.asset.ip_messages.json") is True
-        with open(f"{file_path}/v3.asset.ip_messages.json", "r") as file:
-            lines = file.readlines()
-        assert len(lines) == 1
-        assert lines[0].strip() == expected_output[2].strip()
+        scan_dir = "/output/scan_43_messages"
+        assert os.path.exists(scan_dir)
+        assert len(os.listdir(scan_dir)) == 3
+
+        link_dir = f"{scan_dir}/v3.asset.link_messages"
+        assert os.path.exists(link_dir) is True
+        assert len(os.listdir(link_dir)) == 1
+        with open(f"{link_dir}/0.json", "r") as file:
+            assert file.read().strip() == expected_output[0].strip()
+
+        domain_dir = f"{scan_dir}/v3.asset.domain_name_messages"
+        assert os.path.exists(domain_dir) is True
+        assert len(os.listdir(domain_dir)) == 1
+        with open(f"{domain_dir}/0.json", "r") as file:
+            assert file.read().strip() == expected_output[1].strip()
+
+        ip_dir = f"{scan_dir}/v3.asset.ip_messages"
+        assert os.path.exists(ip_dir) is True
+        assert len(os.listdir(ip_dir)) == 1
+        with open(f"{ip_dir}/0.json", "r") as file:
+            assert file.read().strip() == expected_output[2].strip()
 
 
 def testAgentNebula_whenMessagesDirnameIsSpecified_persistInMessagesDir(
@@ -150,9 +197,13 @@ def testAgentNebula_whenMessagesDirnameIsSpecified_persistInMessagesDir(
 
         nebula_test_agent.process(link_message)
 
-        assert os.path.exists("/output/test_dir")
-        assert len(os.listdir("/output/test_dir")) == 1
-        with open("/output/test_dir/v3.asset.link_messages.json") as file:
+        output_dir = "/output/test_dir"
+        assert os.path.exists(output_dir)
+        assert len(os.listdir(output_dir)) == 1
+        message_dir = f"{output_dir}/v3.asset.link_messages"
+        assert os.path.exists(message_dir)
+        assert len(os.listdir(message_dir)) == 1
+        with open(f"{message_dir}/0.json") as file:
             assert sorted(json.load(file).items()) == sorted(
                 json.loads(expected_output).items()
             )

--- a/tests/nebula_agent_test.py
+++ b/tests/nebula_agent_test.py
@@ -54,10 +54,10 @@ def testAgentNebula_whenFileTypeIsJson_persistMessage(
         nebula_test_agent.process(link_message)
 
         scan_dir = "/output/scan_43_messages"
-        assert os.path.exists(scan_dir)
+        assert os.path.exists(scan_dir) is True
         assert len(os.listdir(scan_dir)) == 1
         message_dir = f"{scan_dir}/v3.asset.link_messages"
-        assert os.path.exists(message_dir)
+        assert os.path.exists(message_dir) is True
         assert len(os.listdir(message_dir)) == 1
         with open(f"{message_dir}/0.json") as file:
             assert sorted(json.load(file).items()) == sorted(
@@ -86,10 +86,10 @@ def testAgentNebula_whenFileTypeIsJson_persistMultipleLinkMessages(
             nebula_test_agent.process(message)
 
         scan_dir = "/output/scan_43_messages"
-        assert os.path.exists(scan_dir)
+        assert os.path.exists(scan_dir) is True
         assert len(os.listdir(scan_dir)) == 1
         message_dir = f"{scan_dir}/v3.asset.link_messages"
-        assert os.path.exists(message_dir)
+        assert os.path.exists(message_dir) is True
         files = sorted(os.listdir(message_dir))
         assert len(files) == len(expected_output)
         for i, expected in enumerate(expected_output):
@@ -125,10 +125,10 @@ def testAgentNebula_whenFileTypeIsUbjson_persistMessage(
         nebula_test_agent.process(link_message)
 
         scan_dir = "/output/scan_43_messages"
-        assert os.path.exists(scan_dir)
+        assert os.path.exists(scan_dir) is True
         assert len(os.listdir(scan_dir)) == 1
         message_dir = f"{scan_dir}/v3.asset.link_messages"
-        assert os.path.exists(message_dir)
+        assert os.path.exists(message_dir) is True
         assert len(os.listdir(message_dir)) == 1
         with open(f"{message_dir}/0.ubjson", "rb") as file:
             assert ubjson.load(file) == expected_output
@@ -159,7 +159,7 @@ def testAgentNebula_whenFileTypeIsJson_persistMultipleMessages(
             nebula_test_agent.process(message)
 
         scan_dir = "/output/scan_43_messages"
-        assert os.path.exists(scan_dir)
+        assert os.path.exists(scan_dir) is True
         assert len(os.listdir(scan_dir)) == 3
 
         link_dir = f"{scan_dir}/v3.asset.link_messages"
@@ -198,10 +198,10 @@ def testAgentNebula_whenMessagesDirnameIsSpecified_persistInMessagesDir(
         nebula_test_agent.process(link_message)
 
         output_dir = "/output/test_dir"
-        assert os.path.exists(output_dir)
+        assert os.path.exists(output_dir) is True
         assert len(os.listdir(output_dir)) == 1
         message_dir = f"{output_dir}/v3.asset.link_messages"
-        assert os.path.exists(message_dir)
+        assert os.path.exists(message_dir) is True
         assert len(os.listdir(message_dir)) == 1
         with open(f"{message_dir}/0.json") as file:
             assert sorted(json.load(file).items()) == sorted(


### PR DESCRIPTION
### Changes

1.  Add support for persisting messages in `ubjson` format.
2. Instead of appending all messages of the same type to a single file, each message is now saved in its own separate file.
    - Messages are grouped into directories based on their selector (e.g., `v3.asset.ip_messages/`).
    - Each message file is named with an incrementing integer to preserve the order of arrival (e.g., `0.json`, `1.json`, etc.).

Support for ubjson was added to allow storing messages that contain binary data, such as application bytes. Unlike json, ubsjon uses a binary format, so storing messages per line no longer works. For this reason, we now store one message per file.