### PR TITLE
feature: Add UTF-8 cleartext option to message persistence

### DIFF
--- a/agent/nebula_agent.py
+++ b/agent/nebula_agent.py
@@ -30,13 +30,26 @@ class CustomEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def _write_json(data: Any, path: pathlib.Path) -> None:
+class Utf8Encoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, bytes) is True:
+            try:
+                return obj.decode("utf-8")
+            except UnicodeDecodeError as e:
+                return f"<Decoding Error: {e}>"
+        return json.JSONEncoder.default(self, obj)
+
+
+def _write_json(data: Any, path: pathlib.Path, utf8: bool = False) -> None:
     """Write data to a JSON file."""
     with open(path, "w") as f:
         f.write(json.dumps(data, cls=CustomEncoder))
+        if utf8 is True:
+            f.write("\n")
+            f.write(json.dumps(data, cls=Utf8Encoder))
 
 
-def _write_ubjson(data: Any, path: pathlib.Path) -> None:
+def _write_ubjson(data: Any, path: pathlib.Path, utf8: bool = False) -> None:
     """Write data to a UBJSON file."""
     with open(path, "wb") as f:
         ubjson.dump(data, f)
@@ -58,12 +71,13 @@ class NebulaAgent(agent.Agent):
     ) -> None:
         super().__init__(agent_definition, agent_settings)
         self._file_type = self.args.get("file_type", "json")
+        self._utf8 = self.args.get("utf8", False)
         if self._file_type.lower() not in SUPPORTED_FILE_TYPES:
             raise ValueError(
                 f"File type {self._file_type} is not supported. Supported file types are {list(SUPPORTED_FILE_TYPES.keys())}"
             )
 
-        self._writer: Callable[[Any, pathlib.Path], None] = SUPPORTED_FILE_TYPES[
+        self._writer: Callable[[Any, pathlib.Path, bool], None] = SUPPORTED_FILE_TYPES[
             self._file_type
         ]
 
@@ -104,7 +118,7 @@ class NebulaAgent(agent.Agent):
         order = self._message_order.get(selector, 0)
         file_path = selector_dir / f"{order}.{self._file_type}"
 
-        self._writer(data, file_path)
+        self._writer(data, file_path, self._utf8)
 
         self._message_order[selector] = order + 1
 

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -70,10 +70,10 @@ source: https://github.com/Ostorlab/agent_nebula
 in_selectors:
   - v3
 out_selectors: []
-docker_file_path : Dockerfile
-docker_build_root : .
+docker_file_path: Dockerfile
+docker_build_root: .
 mounts:
-  - '$CONFIG_HOME/:/output/'
+  - "$CONFIG_HOME/:/output/"
 args:
   - name: "file_type"
     type: "string"
@@ -82,4 +82,7 @@ args:
   - name: "output_directory"
     type: "string"
     description: "[Optional] The directory name where to store the scan messages. This is not a path, but a directory name that will be created inside the /output directory."
-
+  - name: "utf8"
+    type: "boolean"
+    description: "[Optional] If True, attempt UTF-8 decoding for bytes (fallback to error message). If False, use base64 encoding for all bytes."
+    value: false

--- a/tests/nebula_agent_test.py
+++ b/tests/nebula_agent_test.py
@@ -207,3 +207,58 @@ def testAgentNebula_whenMessagesDirnameIsSpecified_persistInMessagesDir(
             assert sorted(json.load(file).items()) == sorted(
                 json.loads(expected_output).items()
             )
+
+def testAgentNebula_whenUtf8IsFalse_persistNormalJson(
+    agent_definition: agent_definitions.AgentDefinition,
+    link_message: msg.Message,
+) -> None:
+    os.environ["UNIVERSE"] = "43"
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/nebula",
+        bus_url="NA",
+        bus_exchange_topic="NA",
+        args=[
+            utils_definitions.Arg(
+                name="utf8",
+                type="boolean",
+                value=json.dumps(False).encode(),
+            ),
+        ],
+        healthcheck_port=5301,
+        redis_url="redis://guest:guest@localhost:6379",
+    )
+    with fake_filesystem_unittest.Patcher():
+        nebula_test_agent = nebula_agent.NebulaAgent(agent_definition, settings)
+        nebula_test_agent.process(link_message)
+        with open("/output/scan_43_messages/v3.asset.link_messages/0.json", "r") as file:
+            content = file.read()
+            assert "\n" not in content.strip()
+            assert '"method": "R0VU"' in content
+
+def testAgentNebula_whenUtf8IsTrue_persistBothJson(
+    agent_definition: agent_definitions.AgentDefinition,
+    link_message: msg.Message,
+) -> None:
+    os.environ["UNIVERSE"] = "43"
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/nebula",
+        bus_url="NA",
+        bus_exchange_topic="NA",
+        args=[
+            utils_definitions.Arg(
+                name="utf8",
+                type="boolean",
+                value=json.dumps(True).encode(),
+            ),
+        ],
+        healthcheck_port=5301,
+        redis_url="redis://guest:guest@localhost:6379",
+    )
+    with fake_filesystem_unittest.Patcher():
+        nebula_test_agent = nebula_agent.NebulaAgent(agent_definition, settings)
+        nebula_test_agent.process(link_message)
+        with open("/output/scan_43_messages/v3.asset.link_messages/0.json", "r") as file:
+            lines = file.read().strip().split("\n")
+            assert len(lines) == 2
+            assert '"method": "R0VU"' in lines[0]
+            assert '"method": "GET"' in lines[1]

--- a/tests/nebula_agent_test.py
+++ b/tests/nebula_agent_test.py
@@ -208,6 +208,7 @@ def testAgentNebula_whenMessagesDirnameIsSpecified_persistInMessagesDir(
                 json.loads(expected_output).items()
             )
 
+
 def testAgentNebula_whenUtf8IsFalse_persistNormalJson(
     agent_definition: agent_definitions.AgentDefinition,
     link_message: msg.Message,
@@ -230,10 +231,13 @@ def testAgentNebula_whenUtf8IsFalse_persistNormalJson(
     with fake_filesystem_unittest.Patcher():
         nebula_test_agent = nebula_agent.NebulaAgent(agent_definition, settings)
         nebula_test_agent.process(link_message)
-        with open("/output/scan_43_messages/v3.asset.link_messages/0.json", "r") as file:
+        with open(
+            "/output/scan_43_messages/v3.asset.link_messages/0.json", "r"
+        ) as file:
             content = file.read()
             assert "\n" not in content.strip()
             assert '"method": "R0VU"' in content
+
 
 def testAgentNebula_whenUtf8IsTrue_persistBothJson(
     agent_definition: agent_definitions.AgentDefinition,
@@ -257,7 +261,9 @@ def testAgentNebula_whenUtf8IsTrue_persistBothJson(
     with fake_filesystem_unittest.Patcher():
         nebula_test_agent = nebula_agent.NebulaAgent(agent_definition, settings)
         nebula_test_agent.process(link_message)
-        with open("/output/scan_43_messages/v3.asset.link_messages/0.json", "r") as file:
+        with open(
+            "/output/scan_43_messages/v3.asset.link_messages/0.json", "r"
+        ) as file:
             lines = file.read().strip().split("\n")
             assert len(lines) == 2
             assert '"method": "R0VU"' in lines[0]


### PR DESCRIPTION
## Problem
When debugging message content in the Nebula agent, all byte fields are Base64-encoded, making it difficult to inspect the actual values. Developers need to manually decode Base64 strings to understand message content, which is cumbersome and error-prone.

## Solution
Introduce a new optional `utf8` configuration flag (default: `false`) that enables dual-format message persistence:

- **When `utf8=false` (default):** Messages are persisted with all bytes Base64-encoded (existing behavior, backward compatible)
- **When `utf8=true`:** Messages are persisted in two formats separated by a newline:
  1. **First JSON object:** All bytes Base64-encoded (original format)
  2. **Second JSON object:** All bytes decoded to UTF-8 cleartext

This allows developers to easily inspect message content in human-readable format without breaking existing functionality.

## Changes
- Added `Utf8Encoder` class to decode bytes to UTF-8 strings (with error handling)
- Updated `_write_json()` to support dual-format output when `utf8=True`
- Updated `_write_ubjson()` signature for consistency (ignores the flag)
- Added `utf8` argument to `ostorlab.yaml` with default value `false`
- Added comprehensive unit tests covering both `utf8=false` and `utf8=true` scenarios

## Example Output
**With `utf8=true`**, a single message file contains:
```json
{"id": "...", "method": "GET", "headers": [{"name": "SG9zdA==", "value": "d3d3Lmdvb2dsZS5jb20="}], ...}
{"id": "...", "method": "GET", "headers": [{"name": "Host", "value": "www.google.com"}], ...}